### PR TITLE
Return a floating point type when computing builtins.pow

### DIFF
--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -21,7 +21,7 @@ from pythran.tables import pythran_ward
 from pythran.types.conversion import PYTYPE_TO_CTYPE_TABLE, TYPE_TO_SUFFIX
 from pythran.types.types import Types
 from pythran.utils import attr_to_path, pushpop, cxxid, isstr, isnum
-from pythran.utils import isextslice
+from pythran.utils import isextslice, ispowi
 from pythran import metadata, unparse
 
 from math import isnan, isinf
@@ -842,6 +842,10 @@ class CxxFunction(ast.NodeVisitor):
     def visit_BinOp(self, node):
         left = self.visit(node.left)
         right = self.visit(node.right)
+        # special case pow for positive integral exponent
+        if ispowi(node):
+            right = 'std::integral_constant<long, {}>{{}}'.format(
+                node.right.value)
         if isstr(node.left):
             left = "pythonic::types::str({})".format(left)
         elif isstr(node.right):

--- a/pythran/optimizations/pattern_transform.py
+++ b/pythran/optimizations/pattern_transform.py
@@ -150,6 +150,22 @@ class AbsSqrPatternNumpy(AbsSqrPattern):
                        keywords=[])
 
 
+class PowFuncPattern(Pattern):
+    # builtins.pow(X, Y) => X ** Y
+
+    pattern = ast.Call(func=ast.Attribute(
+        value=ast.Name(id=mangle('builtins'), ctx=ast.Load(),
+                       annotation=None,
+                       type_comment=None),
+        attr='pow', ctx=ast.Load()),
+        args=[Placeholder(0), Placeholder(1)],
+        keywords=[])
+
+    @staticmethod
+    def sub():
+        return ast.BinOp(Placeholder(0), ast.Pow(), Placeholder(1))
+
+
 class SqrtPattern(Pattern):
     # X ** .5 => numpy.sqrt(X)
 

--- a/pythran/pythonic/builtins/pow.hpp
+++ b/pythran/pythonic/builtins/pow.hpp
@@ -10,6 +10,25 @@ PYTHONIC_NS_BEGIN
 
 namespace builtins
 {
+  double pow(long x, long y)
+  {
+    return std::pow((double)x, (double)y);
+  }
+
+  template <long N>
+  long pow(long x, std::integral_constant<long, N>)
+  {
+    if (N == 0)
+      return 1;
+    if (N == 1)
+      return x;
+    long tmp = pow(x, std::integral_constant<long, N / 2>{});
+    if (N % 2 == 0)
+      return tmp * tmp;
+    else
+      return tmp * tmp * x;
+  }
+
   template <class... Types>
   auto pow(Types &&... args)
       -> decltype(numpy::functor::power{}(std::forward<Types>(args)...))

--- a/pythran/pythonic/include/builtins/pow.hpp
+++ b/pythran/pythonic/include/builtins/pow.hpp
@@ -8,6 +8,13 @@ PYTHONIC_NS_BEGIN
 
 namespace builtins
 {
+
+  // this is only the case in python if the exponent is negative
+  double pow(long, long);
+  // in that case we are sure we have a positive exponent
+  template <long N>
+  long pow(long, std::integral_constant<long, N>);
+
   template <class... Types>
   auto pow(Types &&... args)
       -> decltype(numpy::functor::power{}(std::forward<Types>(args)...));

--- a/pythran/tests/rosetta/ackermann.py
+++ b/pythran/tests/rosetta/ackermann.py
@@ -24,5 +24,5 @@ def ack3(M, N):
    return (N + 1)   if M == 0 else (
           (N + 2)   if M == 1 else (
           (2*N + 3) if M == 2 else (
-          (8*(2**N - 1) + 5) if M == 3 else (
+          (8*(int(2**N) - 1) + 5) if M == 3 else ( # int conversion is pythran-specific
           ack2(M-1, 1) if N == 0 else ack2(M-1, ack2(M, N-1))))))

--- a/pythran/tests/test_base.py
+++ b/pythran/tests/test_base.py
@@ -465,6 +465,18 @@ def nested_def(a):
     def test_pow(self):
         self.run_test("def pow_(a): return pow(a,5)", 18, pow_=[int])
 
+    def test_pow_op0(self):
+        self.run_test("def pow_op0(a): return a ** 0, a ** 1, a **2, a ** 3, a ** 4, a ** 5, a ** 6, a** 7",
+                      18, pow_op0=[int])
+
+    def test_pow_op1(self):
+        self.run_test("def pow_op1(a): return a ** -0, a ** -1, a **-2, a ** -3, a ** -4, a ** -5, a ** -6, a** -7",
+                      18, pow_op1=[int])
+
+    def test_pow_op2(self):
+        self.run_test("def pow_op2(a): return int(a ** a), a ** -a",
+                      7, pow_op2=[int])
+
     def test_reversed(self):
         self.run_test("def reversed_(l): return [x for x in reversed(l)]", [1,2,3], reversed_=[List[int]])
 

--- a/pythran/types/types.py
+++ b/pythran/types/types.py
@@ -13,7 +13,7 @@ from pythran.passmanager import ModuleAnalysis
 from pythran.tables import operator_to_lambda, MODULES
 from pythran.types.conversion import pytype_to_ctype
 from pythran.types.reorder import Reorder
-from pythran.utils import attr_to_path, cxxid, isnum, isextslice
+from pythran.utils import attr_to_path, cxxid, isnum, isextslice, ispowi
 
 from collections import defaultdict
 from functools import partial
@@ -348,7 +348,13 @@ class Types(ModuleAnalysis):
         [self.combine(node, value) for value in node.values]
 
     def visit_BinOp(self, node):
-        self.generic_visit(node)
+        if ispowi(node):
+            self.visit(node.op)
+            self.visit(node.left)
+            cty = "std::integral_constant<long, %s>" % (node.right.value)
+            self.result[node.right] = self.builder.NamedType(cty)
+        else:
+            self.generic_visit(node)
 
         def F(x, y):
             return self.builder.ExpressionType(

--- a/pythran/utils.py
+++ b/pythran/utils.py
@@ -28,6 +28,14 @@ def isextslice(node):
     return any(isinstance(elt, ast.Slice) for elt in node.elts)
 
 
+def ispowi(node):
+    if not isinstance(node.op, ast.Pow):
+        return False
+    if not isintegral(node.right):
+        return False
+    return node.right.value >= 0
+
+
 def attr_to_path(node):
     """ Compute path and final object for an attribute node """
 


### PR DESCRIPTION
Unless we have a literal exponent. Otherwise we're doomed if the exponent is
negative.

Fix #1730